### PR TITLE
Configure Netlify caching for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Nai-web
+
+Este sitio está configurado para desplegarse en [Netlify](https://www.netlify.com/).
+
+## Caché de recursos
+
+Se añadió `netlify.toml` para servir las imágenes desde `/imgs/` con cabeceras `Cache-Control` de larga duración (`max-age=31536000, immutable`). Esto permite que los recursos se mantengan en la caché del navegador durante un año.
+
+Las demás rutas mantienen `Cache-Control: max-age=0, must-revalidate` para asegurar actualizaciones inmediatas del contenido.
+
+## Verificar el uso de la caché
+
+1. Despliegue el sitio en Netlify.
+2. Abra las herramientas de desarrollo del navegador y vaya a la pestaña **Network**.
+3. Recargue la página.
+4. Vuelva a recargarla y verifique que los recursos bajo `/imgs/` indiquen que se sirven desde la caché (por ejemplo, "from memory cache" o "from disk cache").
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[[headers]]
+  for = "/imgs/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"


### PR DESCRIPTION
## Summary
- add Netlify headers configuration to cache images for a year
- document caching setup and verification steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e5a2fff6883338ff697ccfa726994